### PR TITLE
Form parsing and various concurrency fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+sudo: false
+
+go:
+  - 1.3
+  - 1.4
+  - 1.5
+  - tip
+

--- a/cmd/gryffin-distributed/main_test.go
+++ b/cmd/gryffin-distributed/main_test.go
@@ -4,27 +4,28 @@
 
 package main
 
-import (
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"testing"
+// Unit test for gryffin-distributed is still on todo list.
+//
+// import (
+// 	"net/http"
+// 	"net/http/httptest"
+// 	"os"
+// 	"testing"
 
-	"github.com/yahoo/gryffin"
-	"github.com/yahoo/gryffin/data"
-)
+// 	"github.com/yahoo/gryffin"
+// )
 
-var h = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte("Hello World"))
-})
+// var handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 	w.Write([]byte("Hello World"))
+// })
 
-var ts = httptest.NewServer(h)
+// var ts = httptest.NewServer(handler)
 
-func TestMain(t *testing.T) {
-	if os.Getenv("INTEGRATION") == "" {
-		t.Skip("Skip integration tests.")
-	}
-	scan := gryffin.NewScan("GET", ts.URL, "", data.NewMemoryStore(), os.Stdout)
-	linkChannels(scan)
+// func TestMain(t *testing.T) {
+// 	if os.Getenv("INTEGRATION") == "" {
+// 		t.Skip("Skip integration tests.")
+// 	}
+// 	scan := gryffin.NewScan("GET", ts.URL, "")
+// 	linkChannels(scan)
 
-}
+// }

--- a/cmd/gryffin-standalone/main_test.go
+++ b/cmd/gryffin-standalone/main_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/yahoo/gryffin"
-	"github.com/yahoo/gryffin/data"
 )
 
 var h = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -24,7 +23,7 @@ func TestMain(t *testing.T) {
 	if os.Getenv("INTEGRATION") == "" {
 		t.Skip("Skip integration tests.")
 	}
-	scan := gryffin.NewScan("GET", ts.URL, "", data.NewMemoryStore(), os.Stdout)
+	scan := gryffin.NewScan("GET", ts.URL, "")
 	linkChannels(scan)
 
 }

--- a/fuzzer/arachni/arachni.go
+++ b/fuzzer/arachni/arachni.go
@@ -53,6 +53,10 @@ func (s *Fuzzer) Fuzz(g *gryffin.Scan) (count int, err error) {
 
 	count = s.extract(g, string(output))
 
+	if err != nil {
+		return
+	}
+
 	g.Logm("Arachni.Scan", fmt.Sprintf("Arachni return %t", cmd.ProcessState.Success()))
 	return
 

--- a/fuzzer/arachni/arachni_test.go
+++ b/fuzzer/arachni/arachni_test.go
@@ -16,7 +16,7 @@ func TestFuzzer(t *testing.T) {
 		t.Skip("Skip integration tests.")
 	}
 	s := &Fuzzer{}
-	scan := gryffin.NewScan("GET", "http://127.0.0.1:8081/xss/reflect/full1?in=change_me", "", nil, os.Stdout)
+	scan := gryffin.NewScan("GET", "http://127.0.0.1:8081/xss/reflect/full1?in=change_me", "")
 	c, err := s.Fuzz(scan)
 	if err != nil {
 		t.Error(err)

--- a/fuzzer/dummy/dummy_test.go
+++ b/fuzzer/dummy/dummy_test.go
@@ -14,7 +14,7 @@ import (
 func TestFuzzer(t *testing.T) {
 
 	f := &Fuzzer{}
-	scan := gryffin.NewScan("GET", "http://www.yahoo.com", "", nil, os.Stdout)
+	scan := gryffin.NewScan("GET", "http://www.yahoo.com", "")
 	_, err := f.Fuzz(scan)
 	if err != nil {
 		t.Error(err)

--- a/fuzzer/sqlmap/sqlmap.go
+++ b/fuzzer/sqlmap/sqlmap.go
@@ -79,6 +79,10 @@ func (s *Fuzzer) Fuzz(g *gryffin.Scan) (count int, err error) {
 
 	output, err := cmd.Output()
 
+	if err != nil {
+		return
+	}
+
 	count = s.extract(g, string(output))
 
 	g.Logm("SQLMap.Scan", fmt.Sprintf("SQLMap return %t", cmd.ProcessState.Success()))

--- a/fuzzer/sqlmap/sqlmap_test.go
+++ b/fuzzer/sqlmap/sqlmap_test.go
@@ -17,7 +17,7 @@ func TestFuzzer(t *testing.T) {
 	}
 
 	s := &Fuzzer{}
-	scan := gryffin.NewScan("GET", "http://127.0.0.1:8082/dvwa/vulnerabilities/sqli/?id=1&Submit=Submit", "", nil, os.Stdout)
+	scan := gryffin.NewScan("GET", "http://127.0.0.1:8082/dvwa/vulnerabilities/sqli/?id=1&Submit=Submit", "")
 	c, err := s.Fuzz(scan)
 	if err != nil {
 		t.Error(err)

--- a/global.go
+++ b/global.go
@@ -1,0 +1,21 @@
+// Copyright 2015, Yahoo Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gryffin
+
+import (
+	"io"
+	// "io/ioutil"
+)
+
+var memoryStore = NewGryffinStore(nil)
+var logWriter io.Writer
+
+func SetMemoryStore(m *GryffinStore) {
+	memoryStore = m
+}
+
+func SetLogWriter(w io.Writer) {
+	logWriter = w
+}

--- a/gryffin_test.go
+++ b/gryffin_test.go
@@ -7,10 +7,11 @@ package gryffin
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
+	"reflect"
+	"strings"
 	"testing"
-
-	"github.com/yahoo/gryffin/data"
 )
 
 var h = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -29,58 +30,100 @@ func TestGenRandomID(t *testing.T) {
 
 func TestNewScan(t *testing.T) {
 	t.Parallel()
-	s := NewScan("GET", ts.URL, "", nil, nil)
+	s := NewScan("GET", ts.URL, "")
 	if s == nil {
 		t.Error("Scan is nil.")
 	}
+	// TODO - verify s.DomainAllowed.
 	t.Logf("Jobid: %s.", s.Job.ID)
 }
 
-func TestPoke(t *testing.T) {
+func TestNewScanInvalid(t *testing.T) {
 	t.Parallel()
-	client := &http.Client{}
-	s := NewScan("GET", ts.URL, "", nil, nil)
-	err := s.Poke(client)
+	s := NewScan("GET", "%a", "")
+	if s != nil {
+		t.Error("Scan is not nil with invalid URL.", s.Request)
+	}
+}
+
+func TestNewScanFromJson(t *testing.T) {
+	t.Parallel()
+
+	// Test arbritary url.
+	s := NewScan("GET", ts.URL, "")
+	_ = s.Poke(&http.Client{})
+	j := s.Json()
+
+	if j == nil {
+		t.Error("scan.Json should return a json string.")
+	}
+
+	s2 := NewScanFromJson(j)
+	if s2 == nil {
+		t.Error("NewScanFromJson should return a scan.")
+	}
+	t.Log(s2)
+
+}
+
+func TestGetOrigin(t *testing.T) {
+	t.Parallel()
+	u, _ := url.Parse("http://127.0.0.1:1234/foo/bar?")
+	o := getOrigin(u)
+	if o != "http://127.0.0.1:1234" {
+		t.Error("getOrigin is not valid", u, o)
+	}
+}
+
+func TestScanPoke(t *testing.T) {
+	t.Parallel()
+	s := NewScan("GET", ts.URL, "")
+	err := s.Poke(&http.Client{})
 	if err != nil {
 		t.Error(err)
 	}
 }
 
-// func TestPokeNonExist(t *testing.T) {
-// 	t.Parallel()
-// 	client := &http.Client{}
-// 	s := NewScan("GET", ts.URL, "", nil, nil)
-// 	err := s.Poke(client)
-// 	if err == nil {
-// 		t.Error("Expected error fetching non-existing host.")
-// 	}
-// }
-
-func TestSpawn(t *testing.T) {
+func TestScanPokeInvalidURL(t *testing.T) {
 	t.Parallel()
-	s := NewScan("GET", ts.URL, "", nil, nil)
+	client := &http.Client{}
+	s := NewScan("GET", "/foo", "")
+	err := s.Poke(client)
+	if err == nil {
+		t.Error("Expect an error with invalid scheme.")
+	}
+	t.Log("Negative test: Invalid url got ", err)
+}
+
+func TestScanSpawn(t *testing.T) {
+	t.Parallel()
+	s := NewScan("GET", ts.URL, "")
+	s.Poke(&http.Client{})
 	s2 := s.Spawn()
 	if s.Request.URL != s2.Request.URL {
 		t.Error("Spawn gives a request with different URL.")
 	}
 }
 
-func TestMergeRequest(t *testing.T) {
+func TestScanMergeRequest(t *testing.T) {
 	t.Parallel()
-	s := NewScan("GET", ts.URL, "", nil, nil)
+	s := NewScan("GET", ts.URL, "foo=bar")
+	s.Poke(&http.Client{})
 	s.Request.Header.Set("User-Agent", "foo")
-	r, _ := http.NewRequest("GET", ts.URL, nil)
-	s.MergeRequest(r)
+	s.Cookies = []*http.Cookie{
+		&http.Cookie{Name: "cookie-name-1", Value: "cookie-value-1"},
+	}
 
+	r, _ := http.NewRequest("GET", ts.URL, strings.NewReader("quz=quxx"))
+	s.MergeRequest(r)
 	if s.Request.UserAgent() != "foo" {
 		t.Errorf("Merge request got a different user agent: %s", s.Request.UserAgent())
 	}
-
 }
 
-func TestMergeRequestRelative(t *testing.T) {
+func TestScanMergeRequestRelative(t *testing.T) {
 	t.Parallel()
-	s := NewScan("GET", ts.URL, "", nil, nil)
+	s := NewScan("GET", ts.URL, "")
 	s.Request.Header.Set("User-Agent", "foo")
 	r, _ := http.NewRequest("GET", "/#", nil)
 	s.MergeRequest(r)
@@ -90,9 +133,41 @@ func TestMergeRequestRelative(t *testing.T) {
 	}
 }
 
-func TestRateLimit(t *testing.T) {
+func TestScanReadResponseBody(t *testing.T) {
 	t.Parallel()
-	s := NewScan("GET", ts.URL, "", data.NewMemoryStore(), nil)
+	s := NewScan("GET", ts.URL, "")
+	s.Poke(&http.Client{})
+	s.ReadResponseBody()
+	if s.ResponseBody == "" {
+		t.Error("Empty ResponseBody")
+	}
+	// t.Log(s.ResponseBody)
+}
+
+func TestScanUpdateFingerprint(t *testing.T) {
+	t.Parallel()
+	s := NewScan("GET", "http://127.0.0.1", "")
+	s.UpdateFingerprint()
+	if !reflect.DeepEqual(
+		s.Fingerprint,
+		Fingerprint{0x7233A9A31DEADAF2, 0x7233A9A31DEADAF2, 0xF8A4322BD612093C, 0, 0}) {
+		t.Error("Fingerprint mismatch", s.Fingerprint)
+	}
+}
+
+func TestScanResponseFingerprint(t *testing.T) {
+	t.Parallel()
+	s := NewScan("GET", ts.URL, "")
+	s.Poke(&http.Client{})
+	s.UpdateFingerprint()
+	if s.Fingerprint.ResponseSimilarity != 0x62C1D0803B2AB139 {
+		t.Error("Fingerprint mismatch", s.Fingerprint)
+	}
+}
+
+func TestScanRateLimit(t *testing.T) {
+	t.Parallel()
+	s := NewScan("GET", ts.URL, "")
 	for i := 0; i < 5; i++ {
 		d := s.RateLimit()
 		if d > 0 {
@@ -105,10 +180,89 @@ func TestRateLimit(t *testing.T) {
 	}
 }
 
-func TestLog(t *testing.T) {
+func TestScanIsScanAllowed(t *testing.T) {
 	t.Parallel()
-	s := NewScan("GET", ts.URL, "", nil, os.Stderr)
-	s.Logf("test logf %s", "foo")
+	s := NewScan("GET", "http://foo.com", "")
+
+	r, _ := http.NewRequest("GET", "http://bar.com", nil)
+	s.MergeRequest(r)
+	if s.IsScanAllowed() {
+		t.Error("IsScanAllowed should return false", s)
+	}
+
+	r, _ = http.NewRequest("GET", "http://foo.com/test", nil)
+	s.MergeRequest(r)
+	if !s.IsScanAllowed() {
+		t.Error("IsScanAllowed should return true", s)
+	}
+
+	s2 := NewScan("GET", "/no-domain", "")
+	if !s2.IsScanAllowed() {
+		t.Error("IsScanAllowed should return true", s2.Request.URL)
+	}
+}
+
+func TestScanCrawlAsync(t *testing.T) {
+	// TODO ...
+	t.Parallel()
+}
+
+func TestScanIsDuplicatedPage(t *testing.T) {
+	t.Parallel()
+	s1 := NewScan("GET", ts.URL, "")
+	_ = s1.Poke(&http.Client{})
+	if s1.IsDuplicatedPage() {
+		t.Error("IsDuplicatedPage should return false for the first page", s1)
+	}
+
+	s2 := s1.Spawn()
+	r, _ := http.NewRequest("GET", ts.URL, nil)
+	s2.MergeRequest(r)
+	_ = s2.Poke(&http.Client{})
+	if !s2.IsDuplicatedPage() {
+		t.Errorf("IsDuplicatedPage should return true for the second page with same Job ID.\n1st Page: %064b\n2nd Page: %064b\n",
+			s1.Fingerprint.ResponseSimilarity, s2.Fingerprint.ResponseSimilarity)
+	}
+
+	s3 := Scan(*s1)
+	s3.Job.ID = "ABCDEF123456"
+	if s3.IsDuplicatedPage() {
+		t.Error("IsDuplicatedPage should return false for the a page with new Job ID", s3)
+	}
+
+}
+
+func TestScanFuzz(t *testing.T) {
+	// TODO ...
+	t.Parallel()
+}
+
+func TestScanShouldCrawl(t *testing.T) {
+	t.Parallel()
+	s1 := NewScan("GET", ts.URL, "")
+	if !s1.ShouldCrawl() {
+		t.Error("ShouldCrawl should return true for the first page", s1)
+	}
+
+	s2 := s1.Spawn()
+	r, _ := http.NewRequest("GET", ts.URL, nil)
+	s2.MergeRequest(r)
+
+	if s2.ShouldCrawl() {
+		t.Errorf("ShouldCrawl should return false for the second page with same Job ID.\n1st Page: %064b\n2nd Page: %064b\n",
+			s1.Fingerprint.ResponseSimilarity, s2.Fingerprint.ResponseSimilarity)
+	}
+
+	s3 := Scan(*s1)
+	s3.Job.ID = "ABCDEF123456"
+	if !s3.ShouldCrawl() {
+		t.Error("ShouldCrawl should return true for the a page with new Job ID", s3)
+	}
+}
+
+func TestScanLog(t *testing.T) {
+	t.Parallel()
+	SetLogWriter(os.Stdout)
+	s := NewScan("GET", ts.URL, "")
 	s.Log(s)
-	s.Logm("test service", "foo message")
 }

--- a/renderer/base_test.go
+++ b/renderer/base_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/yahoo/gryffin"
-	"github.com/yahoo/gryffin/data"
 )
 
 func testCrawlAsync(t *testing.T, r gryffin.Renderer) {
@@ -19,7 +18,7 @@ func testCrawlAsync(t *testing.T, r gryffin.Renderer) {
 
 	url := "https://www.yahoo.com/"
 
-	s := gryffin.NewScan("GET", url, "", data.NewMemoryStore(), os.Stdout)
+	s := gryffin.NewScan("GET", url, "")
 	r.Do(s)
 	s = <-r.GetRequestBody()
 	// t.Logf("Got async body %s", s)

--- a/serialize.go
+++ b/serialize.go
@@ -1,0 +1,48 @@
+// Copyright 2015, Yahoo Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gryffin
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func NewScanFromJson(b []byte) *Scan {
+	var scan Scan
+	json.Unmarshal(b, &scan)
+	return &scan
+}
+
+func (s *Scan) Json() []byte {
+	ss := &SerializableScan{
+		s,
+		&SerializableRequest{s.Request, ""},
+		&SerializableResponse{
+			s.Response,
+			&SerializableRequest{s.Request, ""},
+		},
+	}
+	b, err := json.Marshal(ss)
+	if err != nil {
+		s.Error("Json", err)
+	}
+	return b
+
+}
+
+type SerializableScan struct {
+	*Scan
+	Request  *SerializableRequest
+	Response *SerializableResponse
+}
+
+type SerializableResponse struct {
+	*http.Response
+	Request *SerializableRequest
+}
+type SerializableRequest struct {
+	*http.Request
+	Cancel string
+}

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,44 @@
+package gryffin
+
+import (
+	"testing"
+)
+
+func TestNewGryffinStore(t *testing.T) {
+
+	chanUpdate := make(chan []byte)
+
+	store := NewGryffinStore(chanUpdate)
+	_ = store
+	store.See("foo", "oracle", uint64(0x1234))
+	select {
+	case b := <-chanUpdate:
+		t.Log(string(b))
+	default:
+		t.Log("Got Nothing.")
+
+	}
+}
+
+// func TestSharedCache(t *testing.T) {
+
+//  i1 := make(chan []byte, 10)
+//  o1 := make(chan []byte, 10)
+//  s1 := NewGryffinStore(i1, o1)
+
+//  i2 := make(chan []byte, 10)
+//  o2 := make(chan []byte, 10)
+//  s2 := NewGryffinStore(i2, o2)
+
+//  s1.See("testing", uint64(0x1234))
+
+//  msg := <-o1
+//  t.Log("o1", string(msg))
+//  fmt.Println("Send message to i2", string(msg))
+//  i2 <- msg
+
+//  time.Sleep(1 * time.Second)
+
+//  t.Log(s1.Oracles)
+//  t.Log(s2.Oracles)
+// }


### PR DESCRIPTION
Couple fixes and enhancements:
1. form parsing - forward ported from v1 python to v2 go code.
2. moving session and logger out of scan struct.
3. restructure the workgroup in gryffin-standalone.
4. add error check when the fuzzer binary are not available.
5. fix `getOrigin`.
6. renamed function `ApplyLinkRules` to `ShouldCrawl`.
7. fix a logic error in `MergeRequest`.
8. fix a wait lock in `phantomjs.go`
9. rewrite `session.go`
10. add tests for `gryffin.go`. Others to be followed in next pull request.
