### PR TITLE
Sharing the html distance oracle across distributed machines.

### DIFF
--- a/fuzzer/dummy/dummy_test.go
+++ b/fuzzer/dummy/dummy_test.go
@@ -5,7 +5,6 @@
 package dummy
 
 import (
-	"os"
 	"testing"
 
 	"github.com/yahoo/gryffin"

--- a/global.go
+++ b/global.go
@@ -9,7 +9,7 @@ import (
 	// "io/ioutil"
 )
 
-var memoryStore = NewGryffinStore(nil)
+var memoryStore = NewGryffinStore(false)
 var logWriter io.Writer
 
 func SetMemoryStore(m *GryffinStore) {

--- a/global.go
+++ b/global.go
@@ -9,7 +9,7 @@ import (
 	// "io/ioutil"
 )
 
-var memoryStore = NewGryffinStore(false)
+var memoryStore *GryffinStore
 var logWriter io.Writer
 
 func SetMemoryStore(m *GryffinStore) {

--- a/gryffin.go
+++ b/gryffin.go
@@ -74,13 +74,19 @@ type Renderer interface {
 type LogMessage struct {
 	Service string
 	Msg     string
+	Method  string
+	Url     string
+	JobID   string
 	// Fingerprint Fingerprint
-	Method string
-	Url    string
 }
 
 // NewScan creates a scan.
 func NewScan(method, url, post string) *Scan {
+
+	// ensure we got a memory store..
+	if memoryStore == nil {
+		memoryStore = NewGryffinStore()
+	}
 
 	id := GenRandomID()
 
@@ -385,6 +391,7 @@ func (s *Scan) Logm(service, msg string) {
 		// Fingerprint: s.Fingerprint,
 		Method: s.Request.Method,
 		Url:    s.Request.URL.String(),
+		JobID:  s.Job.ID,
 	}
 	s.Log(m)
 }

--- a/serialize.go
+++ b/serialize.go
@@ -10,6 +10,11 @@ import (
 )
 
 func NewScanFromJson(b []byte) *Scan {
+	// ensure we got a memory store..
+	if memoryStore == nil {
+		memoryStore = NewGryffinStore()
+	}
+
 	var scan Scan
 	json.Unmarshal(b, &scan)
 	return &scan

--- a/session_test.go
+++ b/session_test.go
@@ -1,44 +1,40 @@
 package gryffin
 
 import (
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestNewGryffinStore(t *testing.T) {
 
-	chanUpdate := make(chan []byte)
+	t.Parallel()
 
-	store := NewGryffinStore(chanUpdate)
-	_ = store
-	store.See("foo", "oracle", uint64(0x1234))
-	select {
-	case b := <-chanUpdate:
-		t.Log(string(b))
-	default:
-		t.Log("Got Nothing.")
+	store1 := NewGryffinStore(true)
+	store2 := NewGryffinStore(true)
 
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		store1.See("foo", "oracle", uint64(0x1234))
+		b := <-store1.GetSndChan()
+		t.Log("Store1 got ", string(b))
+		store2.GetRcvChan() <- b
+		wg.Done()
+	}()
+
+	wg.Wait()
+	for i := 0; i < 100000; i++ {
+		if store2.Seen("foo", "oracle", uint64(0x1234), 2) {
+			t.Logf("Store2 see the new value in %d microseconds.", i)
+			break
+		}
+		time.Sleep(1 * time.Microsecond)
 	}
+
+	if !store2.Seen("foo", "oracle", uint64(0x1234), 2) {
+		t.Error("2nd store should see the value in oracle.", store2.Oracles)
+	}
+
 }
-
-// func TestSharedCache(t *testing.T) {
-
-//  i1 := make(chan []byte, 10)
-//  o1 := make(chan []byte, 10)
-//  s1 := NewGryffinStore(i1, o1)
-
-//  i2 := make(chan []byte, 10)
-//  o2 := make(chan []byte, 10)
-//  s2 := NewGryffinStore(i2, o2)
-
-//  s1.See("testing", uint64(0x1234))
-
-//  msg := <-o1
-//  t.Log("o1", string(msg))
-//  fmt.Println("Send message to i2", string(msg))
-//  i2 <- msg
-
-//  time.Sleep(1 * time.Second)
-
-//  t.Log(s1.Oracles)
-//  t.Log(s2.Oracles)
-// }

--- a/session_test.go
+++ b/session_test.go
@@ -10,15 +10,21 @@ func TestNewGryffinStore(t *testing.T) {
 
 	t.Parallel()
 
-	store1 := NewGryffinStore(true)
-	store2 := NewGryffinStore(true)
+	store1 := NewSharedGryffinStore()
+	store2 := NewSharedGryffinStore()
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 
 	go func() {
 		store1.See("foo", "oracle", uint64(0x1234))
-		b := <-store1.GetSndChan()
+		var b []byte
+		b = <-store1.GetSndChan()
+		t.Log("Store1 got ", string(b))
+		store2.GetRcvChan() <- b
+
+		store1.See("foo", "hash", uint64(0x5678))
+		b = <-store1.GetSndChan()
 		t.Log("Store1 got ", string(b))
 		store2.GetRcvChan() <- b
 		wg.Done()
@@ -27,14 +33,25 @@ func TestNewGryffinStore(t *testing.T) {
 	wg.Wait()
 	for i := 0; i < 100000; i++ {
 		if store2.Seen("foo", "oracle", uint64(0x1234), 2) {
-			t.Logf("Store2 see the new value in %d microseconds.", i)
+			t.Logf("Store2 see the new oracle value in %d microseconds.", i)
 			break
 		}
 		time.Sleep(1 * time.Microsecond)
 	}
 
 	if !store2.Seen("foo", "oracle", uint64(0x1234), 2) {
-		t.Error("2nd store should see the value in oracle.", store2.Oracles)
+		t.Error("2nd store should see the oracle value in oracle.", store2.Oracles)
 	}
 
+	for i := 0; i < 100000; i++ {
+		if store2.Seen("foo", "hash", uint64(0x5678), 2) {
+			t.Logf("Store2 see the new hash value in %d microseconds.", i)
+			break
+		}
+		time.Sleep(1 * time.Microsecond)
+	}
+
+	if !store2.Seen("foo", "hash", uint64(0x5678), 2) {
+		t.Error("2nd store should see the hash value in hashes.", store2.Hashes)
+	}
 }

--- a/util.go
+++ b/util.go
@@ -15,5 +15,5 @@ func GenRandomID() string {
 	// UUID generation is trivial per RSC in https://groups.google.com/d/msg/golang-dev/zwB0k2mpshc/l3zS3oxXuNwJ
 	buf := make([]byte, 16)
 	io.ReadFull(rand.Reader, buf)
-	return fmt.Sprintf("%x", buf)
+	return fmt.Sprintf("%X", buf)
 }


### PR DESCRIPTION
Changes are:
1. gryffin-distributed now run a `shareCache` function that update the local memory store based on message from NSQ.
2. logger shows JobID in the message
3. refactored session.go (msgIn, msgOut) channels to (snd, rcv) channels
4. remove the use of interface in session.go.
5. GenRandomID now sends uppercase string.
